### PR TITLE
Fix audiofile corruption on windows

### DIFF
--- a/src/text/.gitattributes
+++ b/src/text/.gitattributes
@@ -5,4 +5,4 @@ Samples/** filter=lfs diff=lfs merge=lfs -text
 *.als filter=zcat
 
 # ensure LF line endings on pesky windows machines
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Thank you for ableton-git. Managing versioning of ableton projects with git is wonderful!

I'd like to note that currently ableton-git corrupts all audio files (including those in Samples dir) when used on windows machines :(
I've fixed this issue in this commit



As far as I understand,
* text eol=lf marks all files as text and ensures that \r\n is replaced by \n. Thus all audio files
in ableton-git projects used to get corrupted on
windows machines.

* text=auto eol=lf is more intelligent and changes \r\n to \n only in formats that git recognizes
as text (.md, .txt, etc...)

I checked with a python script that gitattributes
was the source of audio file corrptions in cloned
projects and that after this commit the issue is fixed

In the code below 
* ./orig_proj is a project created with ableton-git that has one audio file 'test_audio.m4a'
* ./cloned_proj - ableton-git cloned orig_proj 
* ./orig_proj__gitatr_altered - similar to orig_proj but with * text=auto eol=lf in .gitattributes
* ./cloned_proj__gitatr_altered - ableton-git cloned orig_proj__gitatr_altered 

```
def compare_audios(cloned_path, orig_path):
    with open(cloned_path, 'rb') as f:
        cloned = f.read()

    with open(orig_path, 'rb') as f:
        orig = f.read()

    print(f'{cloned_path} == {orig_path}: {cloned == orig}')

    orig_deformed = orig.replace(b"\r\n", b"\n")

    print(f'{cloned_path} == {orig_path}.replace(b"\\r\\n", b"\\n"): {cloned == orig_deformed}')


if __name__ == "__main__":

    compare_audios('cloned_proj/test_audio.m4a', 
                   'orig_proj/test_audio.m4a')
    
    print()
    
    compare_audios('cloned_proj__gitatr_altered/test_audio.m4a', 
                   'orig_proj__gitatr_altered/test_audio.m4a')
```

The results:
cloned_proj/test_audio.m4a == orig_proj/test_audio.m4a: False
cloned_proj/test_audio.m4a == orig_proj/test_audio.m4a.replace(b"\r\n", b"\n"): True

cloned_proj__gitatr_altered/test_audio.m4a == orig_proj__gitatr_altered/test_audio.m4a: True
cloned_proj__gitatr_altered/test_audio.m4a == orig_proj__gitatr_altered/test_audio.m4a.replace(b"\r\n", b"\n"): False

